### PR TITLE
Fix deployment: Use force_orphan to avoid git conflicts

### DIFF
--- a/.github/workflows/hugo-deploy.yml
+++ b/.github/workflows/hugo-deploy.yml
@@ -39,4 +39,4 @@ jobs:
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
           commit_message: 'Deploy from dev branch'
-          force_orphan: false
+          force_orphan: true


### PR DESCRIPTION
- Changed force_orphan from false to true
- Fixes 'git failed with exit code 1' error
- Allows clean deployment to master branch