### PR TITLE
Restructure Funding page to use card layout like Team page

### DIFF
--- a/content/funding/boehringer.md
+++ b/content/funding/boehringer.md
@@ -1,0 +1,23 @@
++++
+# Date this page was created.
+date = "2020-01-06"
+
+# Project title.
+title = "Boehringer Ingelheim"
+
+# Project summary to display on homepage.
+summary = "Boehringer Ingelheim"
+
+# Optional image to display on homepage (relative to `static/img/` folder).
+image_preview = "funding/boehringer.png"
+
+# Tags: can be used for filtering projects.
+tags = ["funding"]
+
+# Optional external URL for project (replaces project detail page).
+external_link = "https://www.boehringer-ingelheim.com/"
+
+# Does the project detail page use math formatting?
+math = false
+
++++

--- a/content/funding/erc.md
+++ b/content/funding/erc.md
@@ -1,0 +1,23 @@
++++
+# Date this page was created.
+date = "2020-01-01"
+
+# Project title.
+title = "European Research Council"
+
+# Project summary to display on homepage.
+summary = "ERC"
+
+# Optional image to display on homepage (relative to `static/img/` folder).
+image_preview = "funding/erc.png"
+
+# Tags: can be used for filtering projects.
+tags = ["funding"]
+
+# Optional external URL for project (replaces project detail page).
+external_link = "https://erc.europa.eu/"
+
+# Does the project detail page use math formatting?
+math = false
+
++++

--- a/content/funding/novartis.md
+++ b/content/funding/novartis.md
@@ -1,0 +1,23 @@
++++
+# Date this page was created.
+date = "2020-01-05"
+
+# Project title.
+title = "Novartis"
+
+# Project summary to display on homepage.
+summary = "Novartis"
+
+# Optional image to display on homepage (relative to `static/img/` folder).
+image_preview = "funding/novartis.png"
+
+# Tags: can be used for filtering projects.
+tags = ["funding"]
+
+# Optional external URL for project (replaces project detail page).
+external_link = "https://www.novartis.com/"
+
+# Does the project detail page use math formatting?
+math = false
+
++++

--- a/content/funding/roche.md
+++ b/content/funding/roche.md
@@ -1,0 +1,23 @@
++++
+# Date this page was created.
+date = "2020-01-04"
+
+# Project title.
+title = "Roche"
+
+# Project summary to display on homepage.
+summary = "Roche IHB"
+
+# Optional image to display on homepage (relative to `static/img/` folder).
+image_preview = "funding/roche.png"
+
+# Tags: can be used for filtering projects.
+tags = ["funding"]
+
+# Optional external URL for project (replaces project detail page).
+external_link = "https://www.roche.com/"
+
+# Does the project detail page use math formatting?
+math = false
+
++++

--- a/content/funding/snsf.md
+++ b/content/funding/snsf.md
@@ -1,0 +1,23 @@
++++
+# Date this page was created.
+date = "2020-01-02"
+
+# Project title.
+title = "Swiss National Science Foundation"
+
+# Project summary to display on homepage.
+summary = "SNSF"
+
+# Optional image to display on homepage (relative to `static/img/` folder).
+image_preview = "funding/snsf.png"
+
+# Tags: can be used for filtering projects.
+tags = ["funding"]
+
+# Optional external URL for project (replaces project detail page).
+external_link = "http://www.snf.ch/"
+
+# Does the project detail page use math formatting?
+math = false
+
++++

--- a/content/funding/zeiss.md
+++ b/content/funding/zeiss.md
@@ -1,0 +1,23 @@
++++
+# Date this page was created.
+date = "2020-01-03"
+
+# Project title.
+title = "Zeiss"
+
+# Project summary to display on homepage.
+summary = "Zeiss"
+
+# Optional image to display on homepage (relative to `static/img/` folder).
+image_preview = "funding/zeiss.png"
+
+# Tags: can be used for filtering projects.
+tags = ["funding"]
+
+# Optional external URL for project (replaces project detail page).
+external_link = "https://www.zeiss.com/"
+
+# Does the project detail page use math formatting?
+math = false
+
++++

--- a/content/home/funding.md
+++ b/content/home/funding.md
@@ -1,6 +1,6 @@
 +++
-# Custom widget.
-widget = "custom"
+# Projects widget.
+widget = "projects"
 active = true
 date = "2026-01-23T00:00:00"
 
@@ -10,46 +10,20 @@ subtitle = "Supported by"
 # Order that this section will appear in.
 weight = 8
 
+# Content.
+# Display content from the following folder.
+folder = "funding"
+
+# View.
+# Customize how projects are displayed.
+# Legend: 0 = list, 1 = cards.
+view = 1
+
+# Number of items to display (0 = all)
+count = 0
+
+# Filter toolbar.
+# Default filter index (e.g. 0 corresponds to the first `[[filter]]` instance below).
+filter_default = 0
+
 +++
-
-<div style="text-align: center; padding: 20px 0;">
-  <div style="display: flex; flex-wrap: wrap; justify-content: center; align-items: center; gap: 40px; max-width: 1000px; margin: 0 auto;">
-
-    <div style="flex: 0 1 200px;">
-      <a href="https://erc.europa.eu/" target="_blank">
-        <img src="/img/funding/erc.png" alt="European Research Council" style="max-width: 100%; height: auto;">
-      </a>
-    </div>
-
-    <div style="flex: 0 1 200px;">
-      <a href="http://www.snf.ch/" target="_blank">
-        <img src="/img/funding/snsf.png" alt="Swiss National Science Foundation" style="max-width: 100%; height: auto;">
-      </a>
-    </div>
-
-    <div style="flex: 0 1 200px;">
-      <a href="https://www.zeiss.com/" target="_blank">
-        <img src="/img/funding/zeiss.png" alt="Zeiss" style="max-width: 100%; height: auto;">
-      </a>
-    </div>
-
-    <div style="flex: 0 1 200px;">
-      <a href="https://www.roche.com/" target="_blank">
-        <img src="/img/funding/roche.png" alt="Roche IHB" style="max-width: 100%; height: auto;">
-      </a>
-    </div>
-
-    <div style="flex: 0 1 200px;">
-      <a href="https://www.novartis.com/" target="_blank">
-        <img src="/img/funding/novartis.png" alt="Novartis" style="max-width: 100%; height: auto;">
-      </a>
-    </div>
-
-    <div style="flex: 0 1 200px;">
-      <a href="https://www.boehringer-ingelheim.com/" target="_blank">
-        <img src="/img/funding/boehringer.png" alt="Boehringer Ingelheim" style="max-width: 100%; height: auto;">
-      </a>
-    </div>
-
-  </div>
-</div>


### PR DESCRIPTION
- Change from custom HTML widget to projects widget
- Create individual markdown files for each funder in content/funding/
- Each funder now displays as a card with logo, similar to team members
- Fixes issue where logos were not displaying correctly